### PR TITLE
Support for data sources with heterogeneous cell reuse identifiers

### DIFF
--- a/TGRDataSource/TGRArrayDataSource.h
+++ b/TGRDataSource/TGRArrayDataSource.h
@@ -46,14 +46,18 @@ cellReuseIdentifier:(NSString *)reuseIdentifier
  configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
 
 /**
- Initializes the data source without a default cell reuse identifier.
+ Initializes the data source with a custom cell reuse identifier block.
  
  @param items The items managed by the data source.
- @param configureCellBlock A block that will be called when the view asks for a cell in a particular location.
+ @param reuseIdentifierBlock A block that will be called when the view asks for
+ the reuse identifier of cell in a particular location.
+ @param configureCellBlock A block that will be called when the view asks for a 
+ cell in a particular location.
  
  @return An initialized data source.
  */
-- (id)initWithItems:(NSArray *)items
- configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
+-  (id)initWithItems:(NSArray *)items
+reuseIdentifierBlock:(TGRDataSourceReuseIdentifierBlock)reuseIdentifierBlock
+  configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
 
 @end

--- a/TGRDataSource/TGRArrayDataSource.h
+++ b/TGRDataSource/TGRArrayDataSource.h
@@ -36,7 +36,7 @@
  Initializes the data source.
  
  @param items The items managed by the data source.
- @param reuseIdentifier The cell reuse identifier.
+ @param reuseIdentifier The default cell reuse identifier.
  @param configureCellBlock A block that will be called when the view asks for a cell in a particular location.
  
  @return An initialized data source.
@@ -45,5 +45,15 @@
 cellReuseIdentifier:(NSString *)reuseIdentifier
  configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
 
+/**
+ Initializes the data source without a default cell reuse identifier.
+ 
+ @param items The items managed by the data source.
+ @param configureCellBlock A block that will be called when the view asks for a cell in a particular location.
+ 
+ @return An initialized data source.
+ */
+- (id)initWithItems:(NSArray *)items
+ configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
 
 @end

--- a/TGRDataSource/TGRArrayDataSource.m
+++ b/TGRDataSource/TGRArrayDataSource.m
@@ -28,7 +28,8 @@
 cellReuseIdentifier:(NSString *)reuseIdentifier
  configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock
 {
-    self = [super initWithCellReuseIdentifier:reuseIdentifier configureCellBlock:configureCellBlock];
+    self = [super initWithCellReuseIdentifier:reuseIdentifier
+                           configureCellBlock:configureCellBlock];
     
     if (self) {
         _items = [items copy];
@@ -37,12 +38,16 @@ cellReuseIdentifier:(NSString *)reuseIdentifier
     return self;
 }
 
-- (id)initWithItems:(NSArray *)items
- configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock
+-  (id)initWithItems:(NSArray *)items
+reuseIdentifierBlock:(TGRDataSourceReuseIdentifierBlock)reuseIdentifierBlock
+  configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock
 {
-    self = [self initWithItems:items
-           cellReuseIdentifier:nil
-            configureCellBlock:configureCellBlock];
+    self = [super initWithReuseIdentifierBlock:reuseIdentifierBlock
+                            configureCellBlock:configureCellBlock];
+    
+    if (self) {
+        _items = [items copy];
+    }
     
     return self;
 }

--- a/TGRDataSource/TGRArrayDataSource.m
+++ b/TGRDataSource/TGRArrayDataSource.m
@@ -37,6 +37,16 @@ cellReuseIdentifier:(NSString *)reuseIdentifier
     return self;
 }
 
+- (id)initWithItems:(NSArray *)items
+ configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock
+{
+    self = [self initWithItems:items
+           cellReuseIdentifier:nil
+            configureCellBlock:configureCellBlock];
+    
+    return self;
+}
+
 - (id)itemAtIndexPath:(NSIndexPath *)indexPath {
     return self.items[(NSUInteger)indexPath.row];
 }

--- a/TGRDataSource/TGRDataSource.h
+++ b/TGRDataSource/TGRDataSource.h
@@ -22,6 +22,7 @@
 
 #import <UIKit/UIKit.h>
 
+typedef NSString *(^TGRDataSourceReuseIdentifierBlock)(NSIndexPath *indexPath, id item);
 typedef void (^TGRDataSourceCellBlock)(id cell, id item);
 
 /**
@@ -34,6 +35,12 @@ typedef void (^TGRDataSourceCellBlock)(id cell, id item);
  The default cell reuse identifier.
  */
 @property (copy, nonatomic, readonly) NSString *cellReuseIdentifier;
+
+/**
+ A block that will be called when the view asks for the reuse identifier of cell in a 
+ particular location.
+ */
+@property (copy, nonatomic, readonly) TGRDataSourceReuseIdentifierBlock reuseIdentifierBlock;
 
 /**
  A block that will be called when the view asks for a cell in a particular location.
@@ -57,34 +64,23 @@ typedef void (^TGRDataSourceCellBlock)(id cell, id item);
                configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
 
 /**
- Initializes the data source without a default cell reuse identifier.
+ Initializes the data source with a custom cell reuse identifier block.
  
  @discussion This initializer considers the implementation of a table view or
  collection view data source that provides heterogeneous cells. This implies 
- that the `cellReuseIdentifier` property will be ignored and the method 
- `reuseIdentifierForCellAtIndexPath:` must be overriden.
+ that the `cellReuseIdentifier` property will be ignored and the block
+ `reuseIdentifierBlock` will be used in it's place to determine the cell reuse
+ identifier .
  
+ @param reuseIdentifierBlock A block that will be called when the view asks for
+ the reuse identifier of cell in a particular location.
  @param configureCellBlock A block that will be called when the view asks for a
  cell in a particular location.
  
  @return An initialized data source.
  */
-- (id)initWithConfigureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
-
-/**
- Returns a reuse identifier used to dequeue a cell that will be placed
- on a given location.
- 
- @discussion The default implementation of this method simply returns
- the value of the `cellReuseIdentifier` property. Overriding this method allows
- a subclass to use multiple reuse identifiers, which allows the creation
- of table views and collection views composed by heterogeneous cell types.
- 
- @param indexPath The index path specifying the location of the cell.
- 
- @return A reuse identifier specific for that cell
- */
-- (NSString *)reuseIdentifierForCellAtIndexPath:(NSIndexPath *)indexPath;
+- (id)initWithReuseIdentifierBlock:(TGRDataSourceReuseIdentifierBlock)reuseIdentifierBlock
+                configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
 
 /**
  Returns a data source item in a particular location.

--- a/TGRDataSource/TGRDataSource.h
+++ b/TGRDataSource/TGRDataSource.h
@@ -31,7 +31,7 @@ typedef void (^TGRDataSourceCellBlock)(id cell, id item);
 @interface TGRDataSource : NSObject <UITableViewDataSource, UICollectionViewDataSource>
 
 /**
- The cell reuse identifier.
+ The default cell reuse identifier.
  */
 @property (copy, nonatomic, readonly) NSString *cellReuseIdentifier;
 
@@ -43,13 +43,48 @@ typedef void (^TGRDataSourceCellBlock)(id cell, id item);
 /**
  Initializes the data source.
  
- @param reuseIdentifier The cell reuse identifier.
- @param configureCellBlock A block that will be called when the view asks for a cell in a particular location.
+ @discussion This initializer considers the implementation of a data source that 
+ provides homogeneous cells, which means that all cells are dequeued using the 
+ default reuse identifier.
+ 
+ @param reuseIdentifier The default cell reuse identifier.
+ @param configureCellBlock A block that will be called when the view asks for a 
+ cell in a particular location.
  
  @return An initialized data source.
  */
 - (id)initWithCellReuseIdentifier:(NSString *)reuseIdentifier
                configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
+
+/**
+ Initializes the data source without a default cell reuse identifier.
+ 
+ @discussion This initializer considers the implementation of a table view or
+ collection view data source that provides heterogeneous cells. This implies 
+ that the `cellReuseIdentifier` property will be ignored and the method 
+ `reuseIdentifierForCellAtIndexPath:` must be overriden.
+ 
+ @param configureCellBlock A block that will be called when the view asks for a
+ cell in a particular location.
+ 
+ @return An initialized data source.
+ */
+- (id)initWithConfigureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
+
+/**
+ Returns a reuse identifier used to dequeue a cell that will be placed
+ on a given location.
+ 
+ @discussion The default implementation of this method simply returns
+ the value of the `cellReuseIdentifier` property. Overriding this method allows
+ a subclass to use multiple reuse identifiers, which allows the creation
+ of table views and collection views composed by heterogeneous cell types.
+ 
+ @param indexPath The index path specifying the location of the cell.
+ 
+ @return A reuse identifier specific for that cell
+ */
+- (NSString *)reuseIdentifierForCellAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
  Returns a data source item in a particular location.

--- a/TGRDataSource/TGRDataSource.h
+++ b/TGRDataSource/TGRDataSource.h
@@ -32,11 +32,6 @@ typedef void (^TGRDataSourceCellBlock)(id cell, id item);
 @interface TGRDataSource : NSObject <UITableViewDataSource, UICollectionViewDataSource>
 
 /**
- The default cell reuse identifier.
- */
-@property (copy, nonatomic, readonly) NSString *cellReuseIdentifier;
-
-/**
  A block that will be called when the view asks for the reuse identifier of cell in a 
  particular location.
  */
@@ -48,29 +43,27 @@ typedef void (^TGRDataSourceCellBlock)(id cell, id item);
 @property (copy, nonatomic, readonly) TGRDataSourceCellBlock configureCellBlock;
 
 /**
- Initializes the data source.
+ Initializes the data source using a single reuse identifier. 
  
- @discussion This initializer considers the implementation of a data source that 
- provides homogeneous cells, which means that all cells are dequeued using the 
- default reuse identifier.
+ @discussion This initializer internally creates a custom reuse identifier block 
+ that will return the default reuse identifier for all cells. This is useful
+ when a data source provide a single kind of cell, for homogeneous views.
  
- @param reuseIdentifier The default cell reuse identifier.
+ @param defaultReuseIdentifier The default cell reuse identifier.
  @param configureCellBlock A block that will be called when the view asks for a 
  cell in a particular location.
  
  @return An initialized data source.
  */
-- (id)initWithCellReuseIdentifier:(NSString *)reuseIdentifier
+- (id)initWithCellReuseIdentifier:(NSString *)defaultReuseIdentifier
                configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
 
 /**
  Initializes the data source with a custom cell reuse identifier block.
  
- @discussion This initializer considers the implementation of a table view or
- collection view data source that provides heterogeneous cells. This implies 
- that the `cellReuseIdentifier` property will be ignored and the block
- `reuseIdentifierBlock` will be used in it's place to determine the cell reuse
- identifier .
+ @discussion This is the designated initializer of this class. It creates
+ a data source that provides multiple kinds of cell that can be used in
+ the implementation of heterogeneous views.
  
  @param reuseIdentifierBlock A block that will be called when the view asks for
  the reuse identifier of cell in a particular location.

--- a/TGRDataSource/TGRDataSource.m
+++ b/TGRDataSource/TGRDataSource.m
@@ -26,6 +26,7 @@
 @interface TGRDataSource ()
 
 @property (copy, nonatomic) NSString *cellReuseIdentifier;
+@property (copy, nonatomic) TGRDataSourceReuseIdentifierBlock reuseIdentifierBlock;
 @property (copy, nonatomic) TGRDataSourceCellBlock configureCellBlock;
 
 @end
@@ -45,16 +46,17 @@
     return self;
 }
 
-- (id)initWithConfigureCellBlock:(TGRDataSourceCellBlock)configureCellBlock {
+- (id)initWithReuseIdentifierBlock:(TGRDataSourceReuseIdentifierBlock)reuseIdentifierBlock
+                configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock {
+    
     self = [self initWithCellReuseIdentifier:nil
                           configureCellBlock:configureCellBlock];
     
+    if (self) {
+        self.reuseIdentifierBlock = reuseIdentifierBlock;
+    }
+    
     return self;
-}
-
-- (NSString *)reuseIdentifierForCellAtIndexPath:(NSIndexPath *)indexPath {
-    [self subclassResponsibility:_cmd];
-    return nil;
 }
 
 - (id)itemAtIndexPath:(NSIndexPath *)indexPath {
@@ -77,14 +79,15 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView
          cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    id item = [self itemAtIndexPath:indexPath];
+    
     NSString *reuseIdentifier = self.cellReuseIdentifier;
-    if (!reuseIdentifier) {
-        reuseIdentifier = [self reuseIdentifierForCellAtIndexPath:indexPath];
+    if (!reuseIdentifier && self.reuseIdentifierBlock) {
+        reuseIdentifier = self.reuseIdentifierBlock(indexPath, item);
     }
     
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseIdentifier
                                                             forIndexPath:indexPath];
-    id item = [self itemAtIndexPath:indexPath];
     
     if (self.configureCellBlock) {
         self.configureCellBlock(cell, item);
@@ -105,14 +108,15 @@
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
                   cellForItemAtIndexPath:(NSIndexPath *)indexPath
 {
+    id item = [self itemAtIndexPath:indexPath];
+    
     NSString *reuseIdentifier = self.cellReuseIdentifier;
-    if (!reuseIdentifier) {
-        reuseIdentifier = [self reuseIdentifierForCellAtIndexPath:indexPath];
+    if (!reuseIdentifier && self.reuseIdentifierBlock) {
+        reuseIdentifier = self.reuseIdentifierBlock(indexPath, item);
     }
     
     UICollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:reuseIdentifier
                                                                            forIndexPath:indexPath];
-    id item = [self itemAtIndexPath:indexPath];
     
     if (self.configureCellBlock) {
         self.configureCellBlock(cell, item);

--- a/TGRDataSource/TGRDataSource.m
+++ b/TGRDataSource/TGRDataSource.m
@@ -25,7 +25,6 @@
 
 @interface TGRDataSource ()
 
-@property (copy, nonatomic) NSString *cellReuseIdentifier;
 @property (copy, nonatomic) TGRDataSourceReuseIdentifierBlock reuseIdentifierBlock;
 @property (copy, nonatomic) TGRDataSourceCellBlock configureCellBlock;
 
@@ -33,15 +32,15 @@
 
 @implementation TGRDataSource
 
-- (id)initWithCellReuseIdentifier:(NSString *)reuseIdentifier
+- (id)initWithCellReuseIdentifier:(NSString *)defaultReuseIdentifier
                configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock {
-
-    self = [super init];
     
-    if (self) {
-        self.cellReuseIdentifier = reuseIdentifier;
-        self.configureCellBlock = configureCellBlock;
-    }
+    TGRDataSourceReuseIdentifierBlock defaultBlock = ^NSString *(NSIndexPath *indexPath, id item) {
+        return defaultReuseIdentifier;
+    };
+    
+    self = [self initWithReuseIdentifierBlock:defaultBlock
+                           configureCellBlock:configureCellBlock];
     
     return self;
 }
@@ -49,9 +48,7 @@
 - (id)initWithReuseIdentifierBlock:(TGRDataSourceReuseIdentifierBlock)reuseIdentifierBlock
                 configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock {
     
-    self = [self initWithCellReuseIdentifier:nil
-                          configureCellBlock:configureCellBlock];
-    
+    self = [super init];
     if (self) {
         self.reuseIdentifierBlock = reuseIdentifierBlock;
     }
@@ -81,8 +78,8 @@
 {
     id item = [self itemAtIndexPath:indexPath];
     
-    NSString *reuseIdentifier = self.cellReuseIdentifier;
-    if (!reuseIdentifier && self.reuseIdentifierBlock) {
+    NSString *reuseIdentifier = @"";
+    if (self.reuseIdentifierBlock) {
         reuseIdentifier = self.reuseIdentifierBlock(indexPath, item);
     }
     
@@ -110,8 +107,8 @@
 {
     id item = [self itemAtIndexPath:indexPath];
     
-    NSString *reuseIdentifier = self.cellReuseIdentifier;
-    if (!reuseIdentifier && self.reuseIdentifierBlock) {
+    NSString *reuseIdentifier = @"";
+    if (self.reuseIdentifierBlock) {
         reuseIdentifier = self.reuseIdentifierBlock(indexPath, item);
     }
     

--- a/TGRDataSource/TGRDataSource.m
+++ b/TGRDataSource/TGRDataSource.m
@@ -33,8 +33,8 @@
 @implementation TGRDataSource
 
 - (id)initWithCellReuseIdentifier:(NSString *)reuseIdentifier
-               configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock
-{
+               configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock {
+
     self = [super init];
     
     if (self) {
@@ -43,6 +43,18 @@
     }
     
     return self;
+}
+
+- (id)initWithConfigureCellBlock:(TGRDataSourceCellBlock)configureCellBlock {
+    self = [self initWithCellReuseIdentifier:nil
+                          configureCellBlock:configureCellBlock];
+    
+    return self;
+}
+
+- (NSString *)reuseIdentifierForCellAtIndexPath:(NSIndexPath *)indexPath {
+    [self subclassResponsibility:_cmd];
+    return nil;
 }
 
 - (id)itemAtIndexPath:(NSIndexPath *)indexPath {
@@ -62,8 +74,15 @@
     return 0;
 }
 
-- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:self.cellReuseIdentifier
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    NSString *reuseIdentifier = self.cellReuseIdentifier;
+    if (!reuseIdentifier) {
+        reuseIdentifier = [self reuseIdentifierForCellAtIndexPath:indexPath];
+    }
+    
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseIdentifier
                                                             forIndexPath:indexPath];
     id item = [self itemAtIndexPath:indexPath];
     
@@ -86,7 +105,12 @@
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
                   cellForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    UICollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:self.cellReuseIdentifier
+    NSString *reuseIdentifier = self.cellReuseIdentifier;
+    if (!reuseIdentifier) {
+        reuseIdentifier = [self reuseIdentifierForCellAtIndexPath:indexPath];
+    }
+    
+    UICollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:reuseIdentifier
                                                                            forIndexPath:indexPath];
     id item = [self itemAtIndexPath:indexPath];
     

--- a/TGRDataSource/TGRFetchedResultsDataSource.h
+++ b/TGRDataSource/TGRFetchedResultsDataSource.h
@@ -39,7 +39,8 @@
  
  @param controller The `NSFetchedResultsController` object managed by this data source.
  @param reuseIdentifier The cell reuse identifier.
- @param configureCellBlock A block that will be called when the view asks for a cell in a particular location.
+ @param configureCellBlock A block that will be called when the view asks for a cell in 
+ a particular location.
  
  @return An initialized data source.
  */
@@ -51,11 +52,15 @@
  Initializes the data source without a default cell reuse identifier.
  
  @param controller The `NSFetchedResultsController` object managed by this data source.
- @param configureCellBlock A block that will be called when the view asks for a cell in a particular location.
+ @param reuseIdentifierBlock A block that will be called when the view asks for
+ the reuse identifier of cell in a particular location.
+ @param configureCellBlock A block that will be called when the view asks for a cell in 
+ a particular location.
  
  @return An initialized data source.
  */
 - (id)initWithFetchedResultsController:(NSFetchedResultsController *)controller
+                  reuseIdentifierBlock:(TGRDataSourceReuseIdentifierBlock)reuseIdentifierBlock
                     configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
 
 @end

--- a/TGRDataSource/TGRFetchedResultsDataSource.h
+++ b/TGRDataSource/TGRFetchedResultsDataSource.h
@@ -47,4 +47,15 @@
                    cellReuseIdentifier:(NSString *)reuseIdentifier
                     configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
 
+/**
+ Initializes the data source without a default cell reuse identifier.
+ 
+ @param controller The `NSFetchedResultsController` object managed by this data source.
+ @param configureCellBlock A block that will be called when the view asks for a cell in a particular location.
+ 
+ @return An initialized data source.
+ */
+- (id)initWithFetchedResultsController:(NSFetchedResultsController *)controller
+                    configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock;
+
 @end

--- a/TGRDataSource/TGRFetchedResultsDataSource.m
+++ b/TGRDataSource/TGRFetchedResultsDataSource.m
@@ -38,11 +38,15 @@
 }
 
 - (id)initWithFetchedResultsController:(NSFetchedResultsController *)controller
+                  reuseIdentifierBlock:(TGRDataSourceReuseIdentifierBlock)reuseIdentifierBlock
                     configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock
 {
-    self = [self initWithFetchedResultsController:controller
-                              cellReuseIdentifier:nil
-                               configureCellBlock:configureCellBlock];
+    self = [super initWithReuseIdentifierBlock:reuseIdentifierBlock
+                            configureCellBlock:configureCellBlock];
+    
+    if (self) {
+        _fetchedResultsController = controller;
+    }
     
     return self;
 }

--- a/TGRDataSource/TGRFetchedResultsDataSource.m
+++ b/TGRDataSource/TGRFetchedResultsDataSource.m
@@ -37,6 +37,16 @@
     return self;
 }
 
+- (id)initWithFetchedResultsController:(NSFetchedResultsController *)controller
+                    configureCellBlock:(TGRDataSourceCellBlock)configureCellBlock
+{
+    self = [self initWithFetchedResultsController:controller
+                              cellReuseIdentifier:nil
+                               configureCellBlock:configureCellBlock];
+    
+    return self;
+}
+
 - (id)itemAtIndexPath:(NSIndexPath *)indexPath {
     return [self.fetchedResultsController objectAtIndexPath:indexPath];
 }


### PR DESCRIPTION
This PR has a solution for the case of an implementation that uses more than one reuse identifier on the data source. This happens when the view is composed by heterogeneous cells.

The idea is to use a block that provides the reuse identifier for a cell on the given index path. There are some handy new initializers for this case, that will take the reuse identifier block instead of a single reuse identifier string. 
