### PR TITLE
Add delegate method to get reuse identifier for item if reuse identifier is nil

### DIFF
--- a/TGRDataSource/TGRDataSource.h
+++ b/TGRDataSource/TGRDataSource.h
@@ -24,11 +24,32 @@
 
 typedef void (^TGRDataSourceCellBlock)(id cell, id item);
 
+@class TGRDataSource;
+@protocol TGRDataSourceDelegate <NSObject>
+
+@optional
+/**
+ *  Gets reuse identifier for cell when cellReuseIdentifier property is nil.
+ *
+ *  @param dataSource The current data source
+ *  @param item       The data source item
+ *
+ *  @return The reuse identifier for data source item
+ */
+- (NSString *)dataSource:(TGRDataSource *)dataSource reuseIdentifierForItem:(id)item;
+
+@end
+
 /**
  Convenience class to encapsulate an `UITableView` or `UICollectionView` data source. 
  Inspired by http://www.objc.io/issue-1/lighter-view-controllers.html
  */
 @interface TGRDataSource : NSObject <UITableViewDataSource, UICollectionViewDataSource>
+
+/**
+ *  The data source delegate
+ */
+@property (weak, nonatomic) id<TGRDataSourceDelegate>delegate;
 
 /**
  The cell reuse identifier.

--- a/TGRDataSource/TGRDataSource.m
+++ b/TGRDataSource/TGRDataSource.m
@@ -63,9 +63,12 @@
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:self.cellReuseIdentifier
-                                                            forIndexPath:indexPath];
     id item = [self itemAtIndexPath:indexPath];
+    NSString * reuseIdentifier = self.cellReuseIdentifier;
+    if (!reuseIdentifier)
+        reuseIdentifier = [self.delegate dataSource:self reuseIdentifierForItem:item];
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseIdentifier
+                                                            forIndexPath:indexPath];
     
     if (self.configureCellBlock) {
         self.configureCellBlock(cell, item);
@@ -86,9 +89,12 @@
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
                   cellForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    UICollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:self.cellReuseIdentifier
-                                                                           forIndexPath:indexPath];
     id item = [self itemAtIndexPath:indexPath];
+    NSString * reuseIdentifier = self.cellReuseIdentifier;
+    if (!reuseIdentifier)
+        reuseIdentifier = [self.delegate dataSource:self reuseIdentifierForItem:item];
+    UICollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:reuseIdentifier
+                                                                           forIndexPath:indexPath];
     
     if (self.configureCellBlock) {
         self.configureCellBlock(cell, item);


### PR DESCRIPTION
Can be used when collection view uses more than one collection view cell type
